### PR TITLE
Enable bots in KTX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone https://github.com/deurk/mvdsv.git && cd mvdsv/build/make \
 
 # Build ktx
 RUN git clone https://github.com/deurk/ktx.git && cd ktx \
-  && ./configure && make dl
+  && ./configure && make build-dlbots
 
 FROM ubuntu:18.04 as run
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Enable bots in the KTX build.

If you want to give them a try, connect to the server and do the following:
```
/dm4
/botcmd enable
/botcmd addbot
/1on1
/ready
```